### PR TITLE
Add student showcase submission guidelines

### DIFF
--- a/speak.md
+++ b/speak.md
@@ -63,7 +63,7 @@ In 2018, these tracks will be: [DjangoCon, Security and Privacy, Education, and 
 
 You can submit to any or all of these Specialist Tracks [through PaperCall](https://www.papercall.io/pyconau2018).
 
-This year's Education Seminar will feature a Student Showcase in the post afternoon tea session, with presentations specifically from students in Years 7-12. Applications for that will be taken separately - we'll have more details for interested students and teachers soon!
+This year's Education Seminar will feature a Student Showcase in the post afternoon tea session, with presentations specifically from students in Years 7-12. Applications for that are taken separately: see the [Student Showcase submission page](/speak/showcase) for details!
 
 ## <a name="mentors"></a> Mentors
 

--- a/student-showcase.md
+++ b/student-showcase.md
@@ -1,0 +1,91 @@
+---
+layout: page
+title: Student Showcase
+permalink: /speak/showcase
+header-img: /img/headers/hobart-audrey.jpg
+card: /img/cards/speak.jpg
+---
+
+## [Submit a Student Showcase proposal now!](http://bit.ly/pyconau-2018-student-showcase)
+
+In 2018, for the first time, the PyCon Australia Python in Education Seminar will be hosting a
+dedicated afternoon session for high school student presentations.
+
+We are calling for proposals from Australian high school students who are using Python in a project,
+class assignment or who are hacking on something cool.
+Individual students or small groups can apply, and all levels of experience are
+welcome, from complete novices to Python pros.
+
+We are accepting 10-15 minute talk submissions from students from year 7 to 12.
+
+**Student Showcase submissions for 2018 are open from Tuesday, May 1
+[Anywhere On Earth (AoE)](https://en.wikipedia.org/wiki/Anywhere_on_Earth) to Monday, June 4 AoE.**
+
+The Student Showcase will take place as part of the PyCon Australia Python in Education Seminar
+on the afternoon of Friday, August 24th.
+
+The Python in Education Seminar is a dedicated specialist track at PyCon Australia that focuses on
+the use of Python for teaching beginner programmers in the context of a more general education. The
+Student Showcase is an opportunity for students to exhibit their projects and tell the story
+of how they were made, the problems they had to solve, and how Python helped (or hindered!)
+them along the way.
+
+🐍✍️➡️✨
+
+# Contents
+* [Basic information](#basic-information)
+* [How to write your proposal](#how-to-write-your-proposal)
+* [Conduct and expectations](#conduct-and-expectations)
+* [Speaker benefits](#speaker-benefits)
+* [Financial support](#financial-support)
+* [Have a question? Unsure about anything?](#questions)
+
+## <a name="basic-information"></a> Basic information
+
+Are you an Australian student using Python for a school or personal project?
+Submit [a Student Showcase proposal](http://bit.ly/pyconau-2018-student-showcase) if you'd like
+to give a presentation about your project to a mixed audience of fellow students, educators, and
+interested and supportive industry professionals.
+
+Note: even for personal projects, submissions will still need to be coordinated through your
+school (and the submission form reflects this).
+
+**Student Showcase submissions for 2018 are open from Tuesday, May 1
+[Anywhere On Earth (AoE)](https://en.wikipedia.org/wiki/Anywhere_on_Earth) to Monday, June 4 AoE.**
+
+The PyCon Australia Student Showcase is being organised in collaboration with the [Australian
+Computing Academy](https://aca.edu.au/).
+
+## <a name="how-to-write-your-proposal"></a> How to write your proposal
+
+The [Student Showcase submission form](http://bit.ly/pyconau-2018-student-showcase) includes
+several guiding questions to help organise your proposal.
+
+If you have any questions about formulating your proposal, start out by talking to the teacher
+coordinating submissions from your school.
+
+For teachers that have questions, please contact the [Australian Computing Academy](mailto:help@aca.edu.au).
+
+## <a name="conduct-and-expectations"></a> Conduct and expectations
+
+All speakers will be expected to have read and adhere to the conference [Code of Conduct](http://2018.pycon-au.org/conduct/).
+For students in particular: if it wouldn't be appropriate in class, it isn't going to be appropriate at the Education Seminar!
+
+## <a name="speaker-benefits"></a> Speaker benefits
+
+Accepted students will have the opportunity to present their work in front of interested and supportive industry professionals. They will be provided with one free ticket to PyCon Australia 2018, including not only the specialist events day, but also both days of the conference main track.
+
+Arrangements will also be made to allow parents and guardians to attend the Student Showcase itself without needing to purchase a full conference
+ticket.
+
+Proposals which are accepted will receive one free ticket to PyCon Australia 2018. You are welcome to propose a talk with more than one speaker, but please be aware that if it is accepted, only one complimentary ticket will be allocated.
+
+## <a name="financial-support"></a> Financial support
+
+Don't let finances stop you from submitting a talk proposal. Speakers receive free conference tickets and there is further financial assistance available based on need. See the [financial assistance page](/assistance/) for more details about the selection process and a link to the application form.
+
+## <a name="questions"></a> Have a question? Unsure about anything?
+
+If you have any other questions about the Student Showcase, you can reach us any time at **[help@aca.edu.au](mailto:help@aca.edu.au)**.
+
+Alternatively, if you're happy for the question and response to be public, just send a tweet and mention @pyconau and @auscompacademy!


### PR DESCRIPTION
- the end date is exactly 1 week after the end date for the main CFP,
  to match the fact we're also starting a week later
- the main CFP doesn't include an expected date for the end of reviews,
  so I haven't included one here either
- this uses help@aca.edu.au as the primary point of contact, both for
  working-with-children regulatory reasons, and also because that's
  a genuinely better point of contact than the main program organisers
- I'm assuming for now that we simply won't be recording the Student
  Showcase, and hence don't need to ask the video release question
  (we'd need to handle the Student Showcase specially anyway, since
  the students presumably can't make the release on their own behalf)